### PR TITLE
Avoid re-enable disabled buttons

### DIFF
--- a/js/elFinder.command.js
+++ b/js/elFinder.command.js
@@ -155,7 +155,7 @@ elFinder.prototype.command = function(fm) {
 
 		if (this.disableOnSearch) {
 			fm.bind('search searchend', function(e) {
-				self._disabled = e.type == 'search';
+				self._disabled = e.type == 'search' || e.type == 'searchend';
 				self.update(void(0), self.value);
 			});
 		}


### PR DESCRIPTION
...on searchend event

Not knowing what the expected behaviour is suppose to be, I perceived this as a bug. Here's how to reproduce:

1. Click on a folder where some buttons are disabled due to restrictions
2. Those buttons are now disabled
3. Click on the active folder (again)
4. Those buttons are now enabled (by removed class 'ui-state-disabled')